### PR TITLE
Add module entry point for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+### Usage
+
+Once the virtual environment has been activated, you can use the project without installing it by using the following command in the root directory:
+```bash
+python -m projecthub
+```
+
 ## Building
 
 To build the package you need to run

--- a/projecthub/__main__.py
+++ b/projecthub/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+main()


### PR DESCRIPTION
Instead of installing the project with pipx to test it, I added the `__main__.py` folder that make the project work as a module.
It can thus be called with the following command: `python -m projecthub` in the root directory.

Example:
```python -m projecthub --hello```

This is important for later because relative imports can only be used inside a module.